### PR TITLE
view URIs should not be prepended with '/'

### DIFF
--- a/nodejs/collection/app.js
+++ b/nodejs/collection/app.js
@@ -42,7 +42,7 @@ express.bodyParser.parse['application/collection+json'] = JSON.parse;
 /* handle default task list */
 app.get('/collection/tasks/', function(req, res){
 
-  var view = '/_design/example/_view/due_date';
+  var view = '_design/example/_view/due_date';
   
   db.get(view, function (err, doc) {
     res.header('content-type',contentType);
@@ -72,7 +72,7 @@ app.get('/collection/tasks/;template', function(req, res){
 
 app.get('/collection/tasks/;all', function(req, res){
 
-    var view = '/_design/example/_view/all';
+    var view = '_design/example/_view/all';
     
     db.get(view, function (err, doc) {
     res.header('content-type',contentType);
@@ -85,7 +85,7 @@ app.get('/collection/tasks/;all', function(req, res){
 
 app.get('/collection/tasks/;open', function(req, res){
 
-    var view = '/_design/example/_view/open';
+    var view = '_design/example/_view/open';
     
     db.get(view, function (err, doc) {
     res.header('content-type',contentType);
@@ -98,7 +98,7 @@ app.get('/collection/tasks/;open', function(req, res){
 
 app.get('/collection/tasks/;closed', function(req, res){
 
-    var view = '/_design/example/_view/closed';
+    var view = '_design/example/_view/closed';
     
     db.get(view, function (err, doc) {
     res.header('content-type',contentType);
@@ -118,7 +118,7 @@ app.get('/collection/tasks/;date-range', function(req, res){
     options.startkey=String.fromCharCode(34)+d1+String.fromCharCode(34);
     options.endkey=String.fromCharCode(34)+d2+String.fromCharCode(34);
      
-    var view = '/_design/example/_view/due_date';   
+    var view = '_design/example/_view/due_date';
     
     db.get(view, options, function (err, doc) {
     res.header('content-type',contentType);
@@ -133,7 +133,7 @@ app.get('/collection/tasks/;date-range', function(req, res){
 /* handle single task item */
 app.get('/collection/tasks/:i', function(req, res){
 
-    var view = '/'+req.params.i;
+    var view = req.params.i;
     
     db.get(view, function (err, doc) {
     res.header('content-type',contentType);


### PR DESCRIPTION
I needed to remove the leading `/` characters in order for `cradle` to properly retrieve the documents from CouchDB. This is with a fresh install of `express` and `cradle` on NodeJS `v0.6.19`.
